### PR TITLE
feat: auth apis for chrome extension

### DIFF
--- a/api/routes/user.go
+++ b/api/routes/user.go
@@ -12,6 +12,7 @@ func UserRoutes(app fiber.Router, s user.Service) {
 	app.Get("/google-oauth/callback", handlers.GoogleSignin(s))
 	app.Post("/signup", middlewares.ValidateBody(models.SignupDto{}), handlers.Signup(s))
 	app.Post("/signin", middlewares.ValidateBody(models.SigninDto{}), handlers.Signin(s))
+	app.Get("/extension-refresh", handlers.GetExtensionRefreshToken(s))
 	app.Get("/signout", handlers.Signout(s))
 	app.Get("/self", handlers.GetSelf(s))
 	app.Get("/refresh", handlers.GetRefreshToken(s))

--- a/pkg/common/jwt.go
+++ b/pkg/common/jwt.go
@@ -37,7 +37,7 @@ func VerifyJwt(token string, signedJwtKey string) (jwt.MapClaims, error) {
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("invalidate token: %w", err)
+		return nil, fmt.Errorf("invalid token: %w", err)
 	}
 
 	claims, ok := tkn.Claims.(jwt.MapClaims)

--- a/pkg/models/user-models.go
+++ b/pkg/models/user-models.go
@@ -14,6 +14,12 @@ type SignupResponse struct {
 type SigninResponse struct {
 	User entities.User `json:"user"`
 	AccessToken string `json:"access_token"`
+	RefreshToken string
+	ExtRefreshToken string
+}
+
+type ExtensionSigninResponse struct {
+	AccessToken string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 }
 


### PR DESCRIPTION
Enable Catatann Chrome Extension to authenticate through refresh-token

- [ ] Signin with google or credentials now set ctnn_extension_refresh_token for acquiring access token and new refresh token 
- [ ] New API: /api/users/extension-refresh